### PR TITLE
MVV-LVA Move Ordering

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -673,7 +673,7 @@ int32_t negamax(auto &board, auto &threadData, auto ply, auto depth, auto alpha,
     // mvv-lva sorting
     pair<int32_t, uint16_t> scoredMoves[256];
     while (auto move = moves[i++])
-        scoredMoves[i] = {board.state.pieceOn(move >> 4 & 63) > 5 ? 0 : 10 * board.state.pieceOn(move >> 4 & 63) - board.state.pieceOn(move >> 10),
+        scoredMoves[i] = {board.state.pieceOn(move >> 4 & 63) > 5 ? 1 : 9 * board.state.pieceOn(move >> 4 & 63) - board.state.pieceOn(move >> 10),
                           move};
     stable_sort(begin(scoredMoves), end(scoredMoves), greater());
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <iostream>
 #include <sstream>
@@ -5,7 +6,6 @@
 #include <vector>
 
 // minify enable filter delete
-#include <algorithm>
 #include <cassert>
 #include <cctype>
 // minify disable filter delete

--- a/main.cpp
+++ b/main.cpp
@@ -673,13 +673,15 @@ int32_t negamax(auto &board, auto &threadData, auto ply, auto depth, auto alpha,
     // mvv-lva sorting
     pair<int32_t, uint16_t> scoredMoves[256];
     while (auto move = moves[i++])
-        scoredMoves[i] = {board.state.pieceOn(move >> 4 & 63) > 5 ? 0 : 9 * board.state.pieceOn(move >> 4 & 63) - board.state.pieceOn(move >> 10),
+        scoredMoves[i] = {board.state.pieceOn(move >> 4 & 63) > 5 ? 0 : 9 + 9 * board.state.pieceOn(move >> 4 & 63) - board.state.pieceOn(move >> 10),
                           move};
-    stable_sort(scoredMoves, scoredMoves + i - 1, greater());
+    stable_sort(scoredMoves, scoredMoves + i, greater());
 
-    for (int j = 0; j < i; j++)
-        if (!threadData.nodes)
-            cout << "Move " << j << ": " << moveToString(scoredMoves[j].second, board.state.flags[0]) << " (" << scoredMoves[j].first << ")" << endl;
+    //if (!threadData.nodes) {
+    //    auto j = 0;
+    //    while (const auto move = scoredMoves[j++].second)
+    //        cout << moveToString(move, board.state.flags[0]) << " 1" << endl;
+    //}
 
     int32_t bestScore = depth < 1 ? staticEval : -32000;
 

--- a/main.cpp
+++ b/main.cpp
@@ -677,12 +677,6 @@ int32_t negamax(auto &board, auto &threadData, auto ply, auto depth, auto alpha,
                           move};
     stable_sort(scoredMoves, scoredMoves + i, greater());
 
-    //if (!threadData.nodes) {
-    //    auto j = 0;
-    //    while (const auto move = scoredMoves[j++].second)
-    //        cout << moveToString(move, board.state.flags[0]) << " 1" << endl;
-    //}
-
     int32_t bestScore = depth < 1 ? staticEval : -32000;
 
     auto movesMade = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -671,10 +671,9 @@ int32_t negamax(auto &board, auto &threadData, auto ply, auto depth, auto alpha,
     board.generateMoves(moves, depth < 1);
 
     // mvv-lva sorting
-    const int32_t pieceVals[] = {1, 3, 3, 5, 9};
     pair<int32_t, uint16_t> scoredMoves[256];
     while (auto move = moves[i++])
-        scoredMoves[i] = {board.state.pieceOn(move >> 4 & 63) > 5 ? 0 : 10 * pieceVals[board.state.pieceOn(move >> 4 & 63)] - pieceVals[board.state.pieceOn(move >> 10)],
+        scoredMoves[i] = {board.state.pieceOn(move >> 4 & 63) > 5 ? 0 : 10 * board.state.pieceOn(move >> 4 & 63) - board.state.pieceOn(move >> 10),
                           move};
     stable_sort(begin(scoredMoves), end(scoredMoves), greater());
 

--- a/minifier.py
+++ b/minifier.py
@@ -11,7 +11,7 @@ KEYWORDS = ['int', 'return', 'printf', 'struct', 'main', 'std', 'uint16_t', 'uin
             'push_back', 'back', 'pop_back', 'reserve', 'cout', '__builtin_bswap64', '__builtin_ctzll', 'auto',
             'const', 'assert', 'endl', 'for', 'while', 'swap', 'bool', 'if', 'else', 'void', 'string', 'char', 'abs',
             'getline', 'split', 'break', 'length', 'switch', 'case', 'cin', 'istringstream', 'empty', 'continue', 'size',
-            'default', 'using', 'namespace', 'int32_t', '__builtin_popcountll', 'stoi', 'chrono', 'begin', 'end', 'second',
+            'default', 'using', 'namespace', 'int32_t', '__builtin_popcountll', 'stoi', 'chrono', 'second',
             'high_resolution_clock', 'duration_cast', 'milliseconds', 'now', 'max', 'pair', 'stable_sort', 'greater']
 
 global counter, resets

--- a/minifier.py
+++ b/minifier.py
@@ -11,8 +11,8 @@ KEYWORDS = ['int', 'return', 'printf', 'struct', 'main', 'std', 'uint16_t', 'uin
             'push_back', 'back', 'pop_back', 'reserve', 'cout', '__builtin_bswap64', '__builtin_ctzll', 'auto',
             'const', 'assert', 'endl', 'for', 'while', 'swap', 'bool', 'if', 'else', 'void', 'string', 'char', 'abs',
             'getline', 'split', 'break', 'length', 'switch', 'case', 'cin', 'istringstream', 'empty', 'continue', 'size',
-            'default', 'using', 'namespace', 'int32_t', '__builtin_popcountll', 'stoi', 'chrono',
-            'high_resolution_clock', 'duration_cast', 'milliseconds', 'now', 'max']
+            'default', 'using', 'namespace', 'int32_t', '__builtin_popcountll', 'stoi', 'chrono', 'begin', 'end', 'second',
+            'high_resolution_clock', 'duration_cast', 'milliseconds', 'now', 'max', 'pair', 'stable_sort', 'greater']
 
 global counter, resets
 counter = 65  # ASCII A


### PR DESCRIPTION
https://chess.swehosting.se/test/1716/
ELO   | 64.85 +- 20.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
GAMES | N: 336 W: 85 L: 23 D: 228

Size: 2504, +84
Elo: 0.77 e/b
Bench: 1232092