### PR TITLE
Adding some simple eval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifeq ($(MAKECMDGOALS),mini)
 endif
 
 
-CXXFLAGS    := -O3 -std=c++20 -Wall -Wextra -pedantic -DNDEBUG -march=native
+CXXFLAGS    := -stdlib=libc++ -O3 -std=c++20 -Wall -Wextra -pedantic -DNDEBUG -march=native
 
 CXX         := clang++
 SUFFIX      :=

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifeq ($(MAKECMDGOALS),mini)
 endif
 
 
-CXXFLAGS    := -stdlib=libc++ -O3 -std=c++20 -Wall -Wextra -pedantic -DNDEBUG -march=native
+CXXFLAGS    := -O3 -std=c++20 -Wall -Wextra -pedantic -DNDEBUG -march=native
 
 CXX         := clang++
 SUFFIX      :=
@@ -18,7 +18,7 @@ ifeq ($(OS), Windows_NT)
     SUFFIX   := .exe
     CXXFLAGS += -static
 else
-	CXXFLAGS += -pthread
+	CXXFLAGS += -pthread -stdlib=libc++
 endif
 
 OUT := $(EXE)$(SUFFIX)

--- a/main.cpp
+++ b/main.cpp
@@ -62,6 +62,8 @@ uint64_t MaskAntiDiagonal[]{
     0x8000000000000000,
 };
 
+int pEval[]{100, 300, 315, 500, 950};
+
 uint64_t ZobristPieces[768]{};
 
 [[nodiscard]] auto slidingAttacks(uint32_t square, uint64_t occ, uint64_t mask) {
@@ -156,6 +158,10 @@ uint64_t ZobristPieces[768]{};
         str += "nbrq"[move >> 2 & 3];
 
     return str;
+}
+
+auto _edgedist(auto sq){
+  return std::min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
 }
 
 struct BoardState {
@@ -579,7 +585,21 @@ struct Board {
     // minify disable filter delete
 
     int32_t evaluateColor(auto color) {
-        return __builtin_popcountll(state.boards[0] & state.boards[6 + color]) * 100 + __builtin_popcountll(state.boards[1] & state.boards[6 + color]) * 300 + __builtin_popcountll(state.boards[2] & state.boards[6 + color]) * 300 + __builtin_popcountll(state.boards[3] & state.boards[6 + color]) * 500 + __builtin_popcountll(state.boards[4] & state.boards[6 + color]) * 900;
+        auto our = state.boards[6 + color];
+        auto eval = 0;
+        for (auto i = 0; i < 5; i++){
+            auto piece = state.boards[i] & our;
+            eval += __builtin_popcountll(piece) * pEval[i];
+            while (piece){
+                auto sq = __builtin_ctzll(piece);
+                piece &= piece - 1;
+                if (i > 0){
+                    eval += _edgedist(sq) * 5;
+                }
+            }
+        }
+
+        return eval;
     }
 
     int32_t evaluate() {

--- a/main.cpp
+++ b/main.cpp
@@ -62,7 +62,7 @@ uint64_t MaskAntiDiagonal[]{
     0x8000000000000000,
 };
 
-int pEval[]{100, 300, 315, 500, 950};
+int PieceValues[]{100, 300, 315, 500, 950};
 
 uint64_t ZobristPieces[768]{};
 
@@ -160,11 +160,11 @@ uint64_t ZobristPieces[768]{};
     return str;
 }
 
-auto _edgedist(auto sq) {
+[[nodiscard]] auto edgeDistance(auto sq) {
     return min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
 }
 
-auto _relr(auto sq, auto c) {
+[[nodiscard]] auto relativeRank(auto sq, auto c) {
     return c == 0 ? (sq / 8) : 7 - (sq / 8);
 }
 
@@ -589,17 +589,17 @@ struct Board {
     // minify disable filter delete
 
     int32_t evaluateColor(auto color) {
-        auto our = state.boards[6 + color];
+        const auto our = state.boards[6 + color];
         auto eval = 0;
         for (auto i = 0; i < 5; i++) {
             auto piece = state.boards[i] & our;
-            eval += __builtin_popcountll(piece) * pEval[i];
+            eval += __builtin_popcountll(piece) * PieceValues[i];
             while (piece) {
-                auto sq = __builtin_ctzll(piece);
+                const auto sq = __builtin_ctzll(piece);
                 piece &= piece - 1;
-                if (i == 0) eval += _relr(sq, color) * _relr(sq, color);
+                if (i == 0) eval += relativeRank(sq, color) * relativeRank(sq, color);
                 if (i > 0) {
-                    eval += _edgedist(sq) * 5;
+                    eval += edgeDistance(sq) * 5;
                 }
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -244,7 +244,7 @@ struct Board {
     }
 
     void generateFromGetter(auto *&moves, auto targets,
-                            auto(*getter)(uint32_t, uint64_t), auto pieces) const {
+                            auto (*getter)(uint32_t, uint64_t), auto pieces) const {
         while (pieces) {
             const auto from = __builtin_ctzll(pieces);
             pieces &= pieces - 1;

--- a/main.cpp
+++ b/main.cpp
@@ -161,7 +161,7 @@ uint64_t ZobristPieces[768]{};
 }
 
 auto _edgedist(auto sq) {
-    return std::min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
+    return min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
 }
 
 auto _relr(auto sq, auto c) {

--- a/main.cpp
+++ b/main.cpp
@@ -160,11 +160,11 @@ uint64_t ZobristPieces[768]{};
     return str;
 }
 
-auto _edgedist(auto sq){
-  return std::min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
+auto _edgedist(auto sq) {
+    return std::min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
 }
 
-auto _relr(auto sq, auto c){
+auto _relr(auto sq, auto c) {
     return c == 0 ? (sq / 8) : 7 - (sq / 8);
 }
 
@@ -244,7 +244,7 @@ struct Board {
     }
 
     void generateFromGetter(auto *&moves, auto targets,
-                            auto (*getter)(uint32_t, uint64_t), auto pieces) const {
+                            auto(*getter)(uint32_t, uint64_t), auto pieces) const {
         while (pieces) {
             const auto from = __builtin_ctzll(pieces);
             pieces &= pieces - 1;
@@ -591,14 +591,14 @@ struct Board {
     int32_t evaluateColor(auto color) {
         auto our = state.boards[6 + color];
         auto eval = 0;
-        for (auto i = 0; i < 5; i++){
+        for (auto i = 0; i < 5; i++) {
             auto piece = state.boards[i] & our;
             eval += __builtin_popcountll(piece) * pEval[i];
-            while (piece){
+            while (piece) {
                 auto sq = __builtin_ctzll(piece);
                 piece &= piece - 1;
                 if (i == 0) eval += _relr(sq, color) * _relr(sq, color);
-                if (i > 0){
+                if (i > 0) {
                     eval += _edgedist(sq) * 5;
                 }
             }

--- a/main.cpp
+++ b/main.cpp
@@ -598,9 +598,7 @@ struct Board {
                 const auto sq = __builtin_ctzll(piece);
                 piece &= piece - 1;
                 if (i == 0) eval += relativeRank(sq, color) * relativeRank(sq, color);
-                if (i > 0) {
-                    eval += edgeDistance(sq) * 5;
-                }
+                if (i > 0) eval += edgeDistance(sq) * 5;
             }
         }
 

--- a/main.cpp
+++ b/main.cpp
@@ -164,6 +164,10 @@ auto _edgedist(auto sq){
   return std::min(((sq % 8 < 4) ? (sq % 8) : (7 - (sq % 8))), ((sq / 8 < 4) ? (sq / 8) : (7 - (sq / 8))));
 }
 
+auto _relr(auto sq, auto c){
+    return c == 0 ? (sq / 8) : 7 - (sq / 8);
+}
+
 struct BoardState {
     // pnbrqk ours theirs
     uint64_t boards[8] = {
@@ -593,6 +597,7 @@ struct Board {
             while (piece){
                 auto sq = __builtin_ctzll(piece);
                 piece &= piece - 1;
+                if (i == 0) eval += _relr(sq, color) * _relr(sq, color);
                 if (i > 0){
                     eval += _edgedist(sq) * 5;
                 }

--- a/minifier/minifier.py
+++ b/minifier/minifier.py
@@ -16,7 +16,7 @@ KEYWORDS = TYPES + ['return', 'printf', 'struct', 'main', 'std', 'push_back', 'b
                     'endl', 'for', 'while', 'swap', 'if', 'else', 'char', 'abs', 'getline',
                     'break', 'length', 'switch', 'case', 'cin', 'empty', 'continue', 'size',
                     'default', 'using', 'namespace', '__builtin_popcountll', 'stoi', 'chrono', 'second',
-                    'high_resolution_clock', 'duration_cast', 'milliseconds', 'now', 'max', 'pair', 'stable_sort', 'greater']
+                    'high_resolution_clock', 'duration_cast', 'milliseconds', 'now', 'max', 'pair', 'stable_sort', 'greater', 'min']
 global counter, resets
 counter = 65  # ASCII A
 resets = 0  # Number of times the counter has exceeded reset back to A


### PR DESCRIPTION
Add additional yet very simple eval.
Pieces are awarded based on the proximity to center (aprx. +350 elo)
Pawns are awarded based on rank (aprx. +90 elo).

All tests done locally from about 300 games SS, so feel free to re-test

I am not sure if i ever continue with this engine, but this might help